### PR TITLE
Added `debug` config option to output zone data

### DIFF
--- a/dist/xiaomi-vacuum-map-card.js
+++ b/dist/xiaomi-vacuum-map-card.js
@@ -378,6 +378,9 @@ class XiaomiVacuumMapCard extends LitElement {
             const xy2 = this.convertCanvasToRealCoordinates(rect.x + rect.w, rect.y + rect.h);
             zone.push([xy1.x, xy2.y, xy2.x, xy1.y])
         }
+        if (this.config.debug) {
+            alert(zone);
+        }
         this._hass.callService("vacuum", "xiaomi_clean_zone", {
             entity_id: this.config.entity,
             repeats: this.vacuumZonedCleanupRepeats,


### PR DESCRIPTION
I don't have access to an Android device and thus can't use the FloleVac option for determining the zones in my house. This change allows zones to be drawn using the mode: `Zoned cleanup` and the resulting coordinates to be shown on screen, so they can be copied and pasted into the YML config for the card. Requires setting `debug: true` in config first.