### PR TITLE
increase card size from 3 to 5

### DIFF
--- a/dist/xiaomi-vacuum-map-card.js
+++ b/dist/xiaomi-vacuum-map-card.js
@@ -583,7 +583,7 @@ class XiaomiVacuumMapCard extends LitElement {
     }
 
     getCardSize() {
-        return 3;
+        return 5;
     }
 
     convertMapToVacuumRect(rect, repeats) {


### PR DESCRIPTION
This is a more sensible choice, as 1 corresponds to one entity row in other cards.

See for example 
![image](https://user-images.githubusercontent.com/6897215/84661624-e5584800-af1a-11ea-80fb-8e74a90631b1.png)

where the three cards surrounding the `xiaomi-vacuum-map-card` are all of size 4, while the vacuum card is 3. In my specific example, the size is probably even ~6, however, I might have a relatively large image.