### PR TITLE
Change the service calls to vacuum independent versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This card enables you to specify a target or start a zoned cleanup using live or
 | `service` | `string` | `False` | `vacuum.send_command` | Allows to define service used after clicking `Start` button. See: [Defining service](#defining-service) |
 | `ignore_zones_limit` | `boolean` | `False` | `false` | Disables 5 zones limit. Possible values: `true`, `false`. See: [Defining service](#defining-service) |
 | `language` | `string` | `False` | `en` | Language used in the card. Possible values: `cz`, `en`, `de`, `dk`, `es`, `fi`, `fr`, `hu`, `it`, `nl`, `no`, `pl`, `pt`, `ru`, `se`, `sk`, `uk` |
+| `float_coordinates` | `boolean` | `False` | `false` | Coordinates are integers (default) or floats. For STYJ02YM and Viomi vacuums set it to `true` |
 
 ## Example usage:
 ```yaml


### PR DESCRIPTION
The current service call (`vacuum.send_command`) is highly vacuum specific. The xiaomi_miio integration supports vacuum independent calls, e.g. `vacuum_clean_zone`, `vacuum_goto` and `vacuum_clean_segment` (for future improvements).

I have an open PR https://github.com/nqkdev/home-assistant-vacuum-styj02ym/pull/47  adding the same functionality to the Viomi/STYJ02YM driver. With these modifications, both vacuum families could be supported by the same codebase.