### PR TITLE
Fix undefined in icon-list-generator.ts

### DIFF
--- a/src/model/generators/icon-list-generator.ts
+++ b/src/model/generators/icon-list-generator.ts
@@ -162,7 +162,7 @@ export class IconListGenerator {
             },
         } as unknown as IconActionConfig);
 
-        const fanSpeeds = "fan_speed_list" in state.attributes ? state.attributes["fan_speed_list"] : [];
+        const fanSpeeds = "fan_speed_list" in ((state && state.attributes) ? state.attributes["fan_speed_list"] : []);
         for (let i = 0; i < fanSpeeds.length; i++) {
             const fanSpeed = fanSpeeds[i];
             const nextFanSpeed = fanSpeeds[(i + 1) % fanSpeeds.length];


### PR DESCRIPTION
fix this error:
```
Uncaught (in promise) TypeError: a is undefined
    generate xiaomi-vacuum-map-card.js:6531
    _setPresetIndex xiaomi-vacuum-map-card.js:7582
    _firstHass xiaomi-vacuum-map-card.js:7543
    set hass xiaomi-vacuum-map-card.js:7492
```