### PR TITLE
Fix error TypeError: a is undefined and e is undefined

### DIFF
--- a/src/model/generators/icon-list-generator.ts
+++ b/src/model/generators/icon-list-generator.ts
@@ -162,7 +162,7 @@ export class IconListGenerator {
             },
         } as unknown as IconActionConfig);
 
-        const fanSpeeds = "fan_speed_list" in state.attributes ? state.attributes["fan_speed_list"] : [];
+        const fanSpeeds = (state && state.attributes) ? state.attributes["fan_speed_list"] : [];
         for (let i = 0; i < fanSpeeds.length; i++) {
             const fanSpeed = fanSpeeds[i];
             const nextFanSpeed = fanSpeeds[(i + 1) % fanSpeeds.length];

--- a/src/model/generators/tiles-generator.ts
+++ b/src/model/generators/tiles-generator.ts
@@ -31,14 +31,14 @@ export class TilesGenerator {
 
     private static getCommonTiles(state: HassEntity, vacuumEntity: string, language: Language): TileConfig[] {
         const tiles: TileConfig[] = [];
-        if ("status" in state.attributes)
+        if (state && "status" in state.attributes)
             tiles.push({
                 entity: vacuumEntity,
                 label: localize("label.status", language),
                 attribute: "status",
                 icon: "mdi:robot-vacuum",
             } as unknown as TileConfig);
-        if ("battery_level" in state.attributes && "battery_icon" in state.attributes)
+        if (state && "battery_level" in state.attributes && "battery_icon" in state.attributes)
             tiles.push({
                 entity: vacuumEntity,
                 label: localize("label.battery_level", language),
@@ -46,7 +46,7 @@ export class TilesGenerator {
                 icon: state.attributes["battery_icon"],
                 unit: "%",
             } as unknown as TileConfig);
-        if ("battery_level" in state.attributes && !("battery_icon" in state.attributes))
+        if (state && "battery_level" in state.attributes && !("battery_icon" in state.attributes))
             tiles.push({
                 entity: vacuumEntity,
                 label: localize("label.battery_level", language),
@@ -54,7 +54,7 @@ export class TilesGenerator {
                 icon: "mdi:battery",
                 unit: "%",
             } as unknown as TileConfig);
-        if ("fan_speed" in state.attributes)
+        if (state && "fan_speed" in state.attributes)
             tiles.push({
                 entity: vacuumEntity,
                 label: localize("label.fan_speed", language),


### PR DESCRIPTION
Currently for my Roborock S5 Max, I was unable to use this card until fixing the following errors:

- state attributes was undefined in icon-list-generator.ts and in tiles-generator.ts

leading to exceptions being thrown