### PR TITLE
Fix broken UI after 2022.3+ release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.rpt2_cache/
 /dist
 .idea
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xiaomi-vacuum-map-card",
-    "version": "v2.0.10",
+    "version": "v2.0.11",
     "description": "Xiaomi Vacuum Map Card",
     "keywords": [
         "home-assistant",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -1,9 +1,12 @@
-import resolve from "rollup-plugin-node-resolve";
 import typescript from "rollup-plugin-typescript2";
+import commonjs from "rollup-plugin-commonjs";
+import nodeResolve from "rollup-plugin-node-resolve";
 import babel from "rollup-plugin-babel";
-import serve from "rollup-plugin-serve";
 import { terser } from "rollup-plugin-terser";
+import serve from "rollup-plugin-serve";
 import json from "@rollup/plugin-json";
+
+const port = process.env.PORT || 5000;
 
 export default {
     input: ["src/xiaomi-vacuum-map-card.ts"],
@@ -12,7 +15,8 @@ export default {
         format: "es",
     },
     plugins: [
-        resolve(),
+        nodeResolve(),
+        commonjs(),
         typescript(),
         json(),
         babel({
@@ -22,7 +26,7 @@ export default {
         serve({
             contentBase: "./dist",
             host: "0.0.0.0",
-            port: 5000,
+            port: port,
             allowCrossOrigin: true,
             headers: {
                 "Access-Control-Allow-Origin": "*",

--- a/src/renderers/icon-renderer.ts
+++ b/src/renderers/icon-renderer.ts
@@ -27,7 +27,7 @@ export class IconRenderer {
             .vacuum-actions-item {
                 float: left;
                 width: 50px;
-                height: 50px;
+                height: 36px;
                 display: flex;
                 justify-content: center;
                 align-items: center;

--- a/src/renderers/modes-menu-renderer.ts
+++ b/src/renderers/modes-menu-renderer.ts
@@ -6,132 +6,29 @@ export class ModesMenuRenderer {
     public static render(modes: MapMode[], getMode: number, setMode: (number) => void): TemplateResult {
         const getCurrentMode = (): MapMode => modes[getMode];
         return html`
-            <paper-menu-button
-                class="modes-dropdown-menu"
-                vertical-align="bottom"
-                horizontal-align="left"
-                no-animations="true"
-                close-on-activate="true">
-                <div class="modes-dropdown-menu-button" slot="dropdown-trigger" alt="bottom align">
-                    <paper-button class="modes-dropdown-menu-button-button">
-                        <ha-icon icon="${getCurrentMode().icon}" class="dropdown-icon"></ha-icon>
-                    </paper-button>
-                    <div class="modes-dropdown-menu-button-text">${getCurrentMode().name}</div>
-                </div>
-                <paper-listbox
-                    class="modes-dropdown-menu-listbox"
-                    slot="dropdown-content"
-                    selected="${getMode}"
-                    @iron-select="${(e: CustomEvent): void => {
-                        setMode(parseInt(e.detail.item.attributes["mode-id"].value));
-                    }}">
-                    ${modes.map(
-                        (mode, index) => html` <div mode-id="${index}">
-                            <div class="modes-dropdown-menu-entry clickable ${getMode === index ? "selected" : ""}">
-                                <div
-                                    class="modes-dropdown-menu-entry-button-wrapper ${index === 0
-                                        ? "first"
-                                        : ""} ${index === modes.length - 1 ? "last" : ""} ${getMode === index
-                                        ? "selected"
-                                        : ""}">
-                                    <paper-button
-                                        class="modes-dropdown-menu-entry-button ${getMode === index ? "selected" : ""}">
-                                        <ha-icon icon="${mode.icon}"></ha-icon>
-                                    </paper-button>
-                                </div>
-                                <div class="modes-dropdown-menu-entry-text">${mode.name}</div>
-                            </div>
-                        </div>`,
-                    )}
-                </paper-listbox>
-            </paper-menu-button>
+            <ha-button-menu>
+                <mwc-button raised slot="trigger" expandContent="true" label="${getCurrentMode().name}">
+                    <ha-icon slot="icon" icon="${getCurrentMode().icon}"></ha-icon>
+                </mwc-button>
+                ${modes.map(
+                    (mode, index) => html`<mwc-list-item
+                        ?activated=${getMode === index}
+                        @click=${(): void => setMode(index)}
+                    >
+                        <ha-icon icon="${mode.icon}"></ha-icon>
+                        ${mode.name}
+                    </mwc-list-item>`,
+                )}
+            </ha-button-menu>
         `;
     }
 
     public static get styles(): CSSResultGroup {
         return css`
-            .modes-dropdown-menu {
-                border-radius: var(--map-card-internal-big-radius);
-                padding: 0;
-            }
-
-            .modes-dropdown-menu-button {
-                display: inline-flex;
-            }
-
-            .modes-dropdown-menu-button-button {
-                width: 50px;
-                height: 50px;
-                border-radius: var(--map-card-internal-big-radius);
-                display: flex;
-                justify-content: center;
-                background-color: var(--map-card-internal-primary-color);
-                align-items: center;
-            }
-
-            .modes-dropdown-menu-button-text {
-                display: inline-flex;
-                line-height: 50px;
-                background-color: transparent;
-                padding-left: 10px;
-                padding-right: 15px;
-            }
-
-            .modes-dropdown-menu-entry {
-                display: inline-flex;
-                width: 100%;
-            }
-
-            .modes-dropdown-menu-entry.selected {
-                border-radius: var(--map-card-internal-big-radius);
-                background-color: var(--map-card-internal-primary-color);
-                color: var(--map-card-internal-primary-text-color);
-            }
-
-            .modes-dropdown-menu-entry-button-wrapper.first:not(.selected) {
-                border-top-left-radius: var(--map-card-internal-big-radius);
-                border-top-right-radius: var(--map-card-internal-big-radius);
-            }
-
-            .modes-dropdown-menu-entry-button-wrapper.last:not(.selected) {
-                border-bottom-left-radius: var(--map-card-internal-big-radius);
-                border-bottom-right-radius: var(--map-card-internal-big-radius);
-            }
-
-            .modes-dropdown-menu-entry-button.selected {
-                border-start-start-radius: var(--map-card-internal-big-radius);
-                border-end-start-radius: var(--map-card-internal-big-radius);
-                background-color: var(--map-card-internal-primary-color);
-                color: var(--map-card-internal-primary-text-color);
-            }
-
-            .modes-dropdown-menu-entry-button-wrapper {
-                background-color: var(--map-card-internal-secondary-color);
-                color: var(--map-card-internal-secondary-text-color);
-                overflow: hidden;
-            }
-
-            .modes-dropdown-menu-entry-button {
-                width: 50px;
-                height: 50px;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-                background-color: var(--map-card-internal-secondary-color);
-                color: var(--map-card-internal-secondary-text-color);
-            }
-
-            .modes-dropdown-menu-entry-text {
-                display: inline-flex;
-                line-height: 50px;
-                background-color: transparent;
-                padding-left: 10px;
-                padding-right: 15px;
-            }
-
-            .modes-dropdown-menu-listbox {
-                padding: 0;
-                background-color: transparent;
+            mwc-button {
+                --mdc-theme-primary: var(--map-card-internal-primary-color);
+                --mdc-icon-size: 22px;
+                --mdc-shape-small: var(--map-card-internal-big-radius);
             }
         `;
     }

--- a/src/xiaomi-vacuum-map-card.ts
+++ b/src/xiaomi-vacuum-map-card.ts
@@ -1,7 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-// import "@polymer/paper-item/paper-item";
-// import "@polymer/paper-listbox/paper-listbox";
-// import "@polymer/paper-dropdown-menu/paper-dropdown-menu";
 import { css, CSSResultGroup, html, LitElement, PropertyValues, svg, SVGTemplateResult, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators";
 import {
@@ -1471,7 +1468,7 @@ export class XiaomiVacuumMapCard extends LitElement {
 
             .map-actions-item {
                 width: 50px;
-                height: 50px;
+                height: 36px;
                 display: flex;
                 justify-content: center;
                 align-items: center;


### PR DESCRIPTION
Changes:

- The rollup for dev did not work. Now it works
- From now on, it is possible to set the port on which a dev file is served
- The previous `paper-menu-button` and `paper-button` components have been replaced by `ha-button-menu` and `mwc-button`
- Removed redundant styling
- Changed the height of the remaining buttons to 36px for consistency with MWC

Appearance after changes:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/2917861/167229361-dd763b48-a137-4e93-99b2-fd47840bb7e9.png">
<img width="331" alt="image" src="https://user-images.githubusercontent.com/2917861/167229367-da4bdb77-7607-4199-be78-e99fa3109cbe.png">
