### PR TITLE
Update xiaomi-vacuum-map-card.ts

### DIFF
--- a/src/xiaomi-vacuum-map-card.ts
+++ b/src/xiaomi-vacuum-map-card.ts
@@ -466,7 +466,7 @@ export class XiaomiVacuumMapCard extends LitElement {
                         </div>
                         <div class="map-zoom-icons" style="visibility: ${this.mapLocked ? "hidden" : "visible"}">
                             <ha-icon
-                                icon="mdi:restore"
+                                icon="mdi:image-filter-center-focus"
                                 class="icon-on-map clickable ripple"
                                 @click="${this._restoreMap}"></ha-icon>
                             <div class="map-zoom-icons-main">


### PR DESCRIPTION
The goal of the 'Restore' button is to recenter the map on the display.
The previous icon looked like a rotation button, that was confusing in my opinion 
Change 'restore' icon to a 'focus' icon.
![image](https://user-images.githubusercontent.com/53400792/170377093-d23c1235-8ed6-485a-affb-2c6c4bf4274d.png)
