### PR TITLE
[roomba] now support two passes

### DIFF
--- a/src/model/generators/platform_templates/roomba.json
+++ b/src/model/generators/platform_templates/roomba.json
@@ -16,7 +16,7 @@
                         "command": "start",
                         "params": {
                             "pmap_id": "[[pmap_id]]",
-                            "regions": "[{%set s='[[selection]]'|from_json%}{%set v='[[variables]]'|from_json%}{%for i in range(s|length)%} {\"params\": {\"noAutoPasses\": true, \"twoPass\": {%if [[repeats]] == 2 %}true{%else%}false{%endif%}}, \"region_id\": \"{{s[i]}}\", \"type\": \"{{v[i]['type']}}\" }{%if not loop.last%},{%endif%}{%endfor%}]|[[jsonify_jinja]]"
+                            "regions": "[{%set s='[[selection]]'|from_json%}{%set v='[[variables]]'|from_json%}{%for i in range(s|length)%} {\"params\": {\"noAutoPasses\": true, \"twoPass\": {{ (([[repeats]] == 2) | string).lower() }}}, \"region_id\": \"{{s[i]}}\", \"type\": \"{{v[i]['type']}}\" }{%if not loop.last%},{%endif%}{%endfor%}]|[[jsonify_jinja]]"
                         }
                     }
                 }

--- a/src/model/generators/platform_templates/roomba.json
+++ b/src/model/generators/platform_templates/roomba.json
@@ -6,7 +6,8 @@
                 "name": "map_mode.vacuum_clean_segment",
                 "icon": "mdi:floor-plan",
                 "selection_type": "ROOM",
-                "repeats_type": "NONE",
+                "repeats_type": "EXTERNAL",
+                "max_repeats": 2,
                 "service_call_schema": {
                     "service": "vacuum.send_command",
                     "evaluate_data_as_template": true,
@@ -15,7 +16,7 @@
                         "command": "start",
                         "params": {
                             "pmap_id": "[[pmap_id]]",
-                            "regions": "[{%set s='[[selection]]'|from_json%}{%set v='[[variables]]'|from_json%}{%for i in range(s|length)%} {\"region_id\": \"{{s[i]}}\", \"type\": \"{{v[i]['type']}}\" }{%if not loop.last%},{%endif%} {%endfor%}]|[[jsonify_jinja]]"
+                            "regions": "[{%set s='[[selection]]'|from_json%}{%set v='[[variables]]'|from_json%}{%for i in range(s|length)%} {\"params\": {\"noAutoPasses\": true, \"twoPass\": {%if [[repeats]] == 2 %}true{%else%}false{%endif%}}, \"region_id\": \"{{s[i]}}\", \"type\": \"{{v[i]['type']}}\" }{%if not loop.last%},{%endif%}{%endfor%}]|[[jsonify_jinja]]"
                         }
                     }
                 }


### PR DESCRIPTION
Since the last update the roomba app support up to two passes per room.
I implement it at global scale here. (Maybe someone can found a way do to it for each room).  

<details><summary>The full card I validate the new params with:</summary>
<p>

```yaml
type: custom:xiaomi-vacuum-map-card
entity: vacuum.t-800
calibration_source:
  identity: true
vacuum_platform: Roomba
map_source:
  image: https://demo.home-assistant.io/assets/arsaboo/floorplans/main.png
map_locked: true
map_modes:
  - template: vacuum_clean_segment
    variables:
      pmap_id: blablabla
    service_call_schema:
      service: vacuum.send_command
      evaluate_data_as_template: true
      service_data:
        entity_id: '[[entity_id]]'
        command: start
        params:
          pmap_id: '[[pmap_id]]'
          regions: >-
            [{%set s='[[selection]]'|from_json%}{%set
            v='[[variables]]'|from_json%}{%for i in range(s|length)%} {"params":
            {"noAutoPasses": true, "twoPass": {%if [[repeats]] == 2
            %}true{%else%}false{%endif%}}, "region_id": "{{s[i]}}", "type":
            "{{v[i]['type']}}" }{%if not loop.last%},{%endif%}
            {%endfor%}]|[[jsonify_jinja]]
    repeats_type: EXTERNAL
    max_repeats: 2
    predefined_selections:
      - id: 104
        variables:
          type: rid
        outline:
          - - 98
            - 967
          - - 360
            - 967
          - - 360
            - 639
          - - 98
            - 639
        label:
          text: Kitchen
          x: 200
          'y': 720
          offset_y: 30
        icon:
          name: mdi:egg-fried
          x: 200
          'y': 720
      - id: 51
        variables:
          type: rid
        outline:
          - - 301
            - 520
          - - 568
            - 520
          - - 568
            - 458
          - - 775
            - 458
          - - 775
            - 700
          - - 389
            - 700
          - - 389
            - 610
          - - 301
            - 610
        label:
          text: Kitchen2
          x: 540
          'y': 620
        icon:
          name: mdi:egg-fried
          x: 650
          'y': 620
....
....
```
</p>
</details>

<details><summary>The service_data payload looks like this when I copy it:</summary>
<p>

```json
{
  "domain": "vacuum",
  "service": "send_command",
  "serviceData": {
    "entity_id": "vacuum.t-800",
    "command": "start",
    "params": {
      "pmap_id": "blablabla",
      "regions": [
        {
          "params": {
            "noAutoPasses": true,
            "twoPass": false
          },
          "region_id": "104",
          "type": "rid"
        },
        {
          "params": {
            "noAutoPasses": true,
            "twoPass": false
          },
          "region_id": "51",
          "type": "rid"
        }
      ]
    }
  }
}
```
</p>
</details>

Perfectly interpreted by my t-800 .
:apple: 