### PR TITLE
Update nl.json

### DIFF
--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -11,10 +11,10 @@
         "vacuum_goto": "Pin & Go",
         "vacuum_goto_predefined": "Punten",
         "vacuum_clean_segment": "Kamers",
-        "vacuum_clean_point": "Schoonmaak punten",
+        "vacuum_clean_point": "Schoonmaakpunten",
         "vacuum_clean_point_predefined": "Punten",
         "vacuum_clean_zone": "Zone schoonmaak",
-        "vacuum_clean_zone_predefined": "Zone lijst",
+        "vacuum_clean_zone_predefined": "Zonelijst",
         "vacuum_follow_path": "Pad"
     },
     "validation": {
@@ -39,9 +39,9 @@
                 "none_provided": "Geen kalibratiebron opgegeven",
                 "calibration_points": {
                     "invalid_number": "Precies 3 of 4 kalibratiepunten vereist",
-                    "missing_map": "Elk kalibratiepunt moet kaart coördinaten bevatten",
+                    "missing_map": "Elk kalibratiepunt moet kaart-coördinaten bevatten",
                     "missing_vacuum": "Elk kalibratiepunt moet stofzuiger coördinaten bevatten",
-                    "missing_coordinate": "Kaart en stofzuiger kalibratiepunten moeten zowel een x als y coödinaat bevatten"
+                    "missing_coordinate": "Kalibratiepunten van kaart en stofzuiger moeten zowel een X- als Y-coördinaat bevatten"
                 }
             },
             "icons": {
@@ -73,22 +73,22 @@
                 "predefined_selections": {
                     "not_applicable": "Modus {0} ondersteunt geen vooraf gedefinieerde selecties",
                     "zones": {
-                        "missing": "Zone configuratie ontbreekt",
+                        "missing": "Zone-configuratie ontbreekt",
                         "invalid_parameters_number": "Elke zone moet 4 coördinaten hebben"
                     },
                     "points": {
                         "position": {
-                            "missing": "Punten configuratie ontbreekt",
+                            "missing": "Puntenconfiguratie ontbreekt",
                             "invalid_parameters_number": "Elk punt moet 2 coördinaten hebben"
                         }
                     },
                     "rooms": {
                         "id": {
-                            "missing": "Kamer id ontbreekt",
-                            "invalid_format": "Ongeldige kamer id: {0}"
+                            "missing": "Kamer-id ontbreekt",
+                            "invalid_format": "Ongeldige kamer-id: {0}"
                         },
                         "outline": {
-                            "invalid_parameters_number": "Elk punt van de kamer omtrek moet 2 coördinaten hebben"
+                            "invalid_parameters_number": "Elk punt van de kameromtrek moet 2 coördinaten hebben"
                         }
                     },
                     "label": {
@@ -117,7 +117,7 @@
                 "service_call_schema": {
                     "missing": "Serviceoproep schema",
                     "service": {
-                        "missing": "Serviceoproep schema moet een service bevatten",
+                        "missing": "Serviceoproep-schema moet een service bevatten",
                         "invalid": "Ongeldige service: {0}"
                     }
                 }
@@ -154,10 +154,10 @@
             }
         },
         "battery_level": {
-            "label": "Batterij"
+            "label": "Accupercentage"
         },
         "fan_speed": {
-            "label": "Fan snelheid",
+            "label": "Ventilatorsnelheid",
             "value": {
                 "silent": "Stil",
                 "standard": "Standaard",
@@ -199,7 +199,7 @@
         "vacuum_return_to_base": "Terug naar basisstation",
         "vacuum_clean_spot": "Spot schoonmaak",
         "vacuum_locate": "Lokaliseren",
-        "vacuum_set_fan_speed": "Fan snelheid aanpassen"
+        "vacuum_set_fan_speed": "Ventilatorsnelheid aanpassen"
     },
     "unit": {
         "hour_shortcut": "u",
@@ -214,9 +214,9 @@
     },
     "editor": {
         "description": {
-            "before_link": "Deze grafische editor ondersteunt slechts een basis configuratie met een camera entiteit welke gemaakt is met ",
+            "before_link": "Deze grafische editor ondersteunt slechts een basis-configuratie met een camera-entiteit die gemaakt is met ",
             "link_text": "Xiaomi Cloud Map Extractor",
-            "after_link": ". Gebruik de YAML modus voor een geavanceerde configuratie."
+            "after_link": ". Gebruik de YAML-modus voor een meer uitgebreide configuratie."
         },
         "label": {
             "name": "Titel (optioneel)",

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -185,11 +185,37 @@
         "cleaned_area": {
             "label": "Oppervlakte"
         },
+        "total_cleaned_area": {
+            "label": "Total cleaned area"
+        },
         "cleaning_time": {
             "label": "Schoonmaaktijd"
         },
+        "total_cleaning_time": {
+            "label": "Total cleaning time"
+        },
         "mop_left": {
             "label": "Dweil"
+        },
+        "bin_full": {
+            "label": "Bin full",
+            "value": {
+                "true": "Yes",
+                "false": "No"
+            }
+        },
+        "bin_present": {
+            "label": "Bin present",
+            "value": {
+                "true": "Yes",
+                "false": "No"
+            }
+        },
+        "water_volume": {
+            "label": "Water volume"
+        },
+        "mop_pad_humidity": {
+            "label": "Mop pad"
         }
     },
     "icon": {
@@ -224,7 +250,19 @@
             "camera": "Camera-entiteit (verplicht)",
             "vacuum_platform": "stofzuigerplatform (verplicht)",
             "map_locked": "Kaart vergrendelen (optioneel)",
-            "two_finger_pan": "Kaart verplaatsen met twee vingers (optioneel)"
+            "two_finger_pan": "Kaart verplaatsen met twee vingers (optioneel)",
+            "platforms_documentation": "Chosen platform's documentation ({0})",
+            "selection": "Selection:",
+            "copy": "Copy",
+            "copied": "Copied!",
+            "set_static_config": "Generate static config",
+            "config_set": "Config set!\nOpen config editor to adjust it.",
+            "config_set_failed": "Failed to update config.",
+            "generate_rooms_config": "Generate rooms config",
+            "copy_service_call": "Copy service call"
+        },
+        "alerts": {
+            "set_static_config": "You should use this functionality only if you want to manually adjust automatically generated configuration.\nContinue?"
         }
     }
 }

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -186,36 +186,36 @@
             "label": "Oppervlakte"
         },
         "total_cleaned_area": {
-            "label": "Total cleaned area"
+            "label": "Totale schoongemaakte oppervlakte"
         },
         "cleaning_time": {
             "label": "Schoonmaaktijd"
         },
         "total_cleaning_time": {
-            "label": "Total cleaning time"
+            "label": "Totale schoonmaaktijd"
         },
         "mop_left": {
             "label": "Dweil"
         },
         "bin_full": {
-            "label": "Bin full",
+            "label": "Afvalcontainer vol",
             "value": {
                 "true": "Yes",
                 "false": "No"
             }
         },
         "bin_present": {
-            "label": "Bin present",
+            "label": "Afvalcontainer aanwezig",
             "value": {
                 "true": "Yes",
                 "false": "No"
             }
         },
         "water_volume": {
-            "label": "Water volume"
+            "label": "Watervolume"
         },
         "mop_pad_humidity": {
-            "label": "Mop pad"
+            "label": "Dweildoek"
         }
     },
     "icon": {
@@ -248,21 +248,21 @@
             "name": "Titel (optioneel)",
             "entity": "Stofzuigerentiteit (verplicht)",
             "camera": "Camera-entiteit (verplicht)",
-            "vacuum_platform": "stofzuigerplatform (verplicht)",
+            "vacuum_platform": "Stofzuigerplatform (verplicht)",
             "map_locked": "Kaart vergrendelen (optioneel)",
             "two_finger_pan": "Kaart verplaatsen met twee vingers (optioneel)",
-            "platforms_documentation": "Chosen platform's documentation ({0})",
-            "selection": "Selection:",
-            "copy": "Copy",
-            "copied": "Copied!",
-            "set_static_config": "Generate static config",
-            "config_set": "Config set!\nOpen config editor to adjust it.",
-            "config_set_failed": "Failed to update config.",
-            "generate_rooms_config": "Generate rooms config",
-            "copy_service_call": "Copy service call"
+            "platforms_documentation": "Documentatie van gekozen stofzuigerplatform ({0})",
+            "selection": "Selectie:",
+            "copy": "Kopiëren",
+            "copied": "Gekopieerd!",
+            "set_static_config": "Statische configuratie aanmaken",
+            "config_set": "Configuratie ingesteld!\nOpen de configuratie-editor om deze aan te passen.",
+            "config_set_failed": "Bijwerken van de configuratie mislukt",
+            "generate_rooms_config": "Kamer-configuratie aanmaken",
+            "copy_service_call": "Service Call kopiëren"
         },
         "alerts": {
-            "set_static_config": "You should use this functionality only if you want to manually adjust automatically generated configuration.\nContinue?"
+            "set_static_config": "Gebruik deze functionaliteit alleen als je de gegenereerde configuratie nog handmatig wil aanpassen.\nDoorgaan?"
         }
     }
 }

--- a/src/localize/languages/nl.json
+++ b/src/localize/languages/nl.json
@@ -161,7 +161,7 @@
             "value": {
                 "silent": "Stil",
                 "standard": "Standaard",
-                "medium": "Medium",
+                "medium": "Gemiddeld",
                 "turbo": "Turbo",
                 "auto": "Automatisch",
                 "gentle": "Zacht"
@@ -220,8 +220,8 @@
         },
         "label": {
             "name": "Titel (optioneel)",
-            "entity": "Stofzuiger entiteit (verplicht)",
-            "camera": "Camera entiteit (verplicht)",
+            "entity": "Stofzuigerentiteit (verplicht)",
+            "camera": "Camera-entiteit (verplicht)",
             "vacuum_platform": "stofzuigerplatform (verplicht)",
             "map_locked": "Kaart vergrendelen (optioneel)",
             "two_finger_pan": "Kaart verplaatsen met twee vingers (optioneel)"


### PR DESCRIPTION
Update some improper Dutch to better wording.

Voor de Nederlanders:

In het Nederlands is een batterij een niet-oplaadbaar ding. Een oplaadbare variant noemen we hier een accu. In het Nederlands schrijf je alles aaneengesloten, en zonder spaties. Al het andere wordt de Engelse ziekte genoemd (https://nl.wikipedia.org/wiki/Engelse_ziekte_(taal))