### PR TITLE
Add `section_type` to `vacuum_clean_zone_predefined` config section.

### DIFF
--- a/docs/templates/hypferValetudo.md
+++ b/docs/templates/hypferValetudo.md
@@ -139,6 +139,7 @@ To retrieve map image you have to use [MQTT Vacuum Camera](https://github.com/sc
   ```yaml
   map_modes:
     - template: vacuum_clean_zone_predefined
+      selection_type: PREDEFINED_RECTANGLE
       predefined_selections:
         - zones: [[ 21485, 28767, 24236, 32131 ], [ 23217, 27379, 24216, 28737 ]]
           label:


### PR DESCRIPTION
See my (editted) comment https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card/issues/724#issuecomment-2254232430 (in the wrong topic) referring https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card/issues/662#issuecomment-1741713714.

This PR adds the missing `section_type` to the docs.