### PR TITLE
Remove reliance on state object existence when rendering tiles

### DIFF
--- a/src/components/tile.ts
+++ b/src/components/tile.ts
@@ -44,7 +44,6 @@ export class Tile extends RootlessLitElement {
         }
         this.className = `tile-wrapper clickable ripple ${this.config.tile_id ? `tile-${this.config.tile_id}-wrapper` : ""}`;
         const stateObj = this.config.entity ? this.hass.states[this.config.entity] : undefined;
-        if (!stateObj) return;
         const title = this.getTileLabel(stateObj);
         const value = this.getTileValue(stateObj);
         const icon = this.getIcon(stateObj);


### PR DESCRIPTION
Changelog:
* Removed condition checking for the state object when rendering tile

Tile rendering allows for retrieving the tile's value from internal variables. That can be combined with various `tap_action`s that turn a tile into a button without the need for the tile to be related to an entity.
Since the other methods in the tile rendering do not particularly require the presence of a state object in the arguments, I found it fitting to remove said condition that prevented render.