### PR TITLE
Fix repeat value placement for zone cleaning payload in valetudo template

### DIFF
--- a/src/model/generators/platform_templates/hypfer_valetudo.json
+++ b/src/model/generators/platform_templates/hypfer_valetudo.json
@@ -33,7 +33,7 @@
                     "evaluate_data_as_template": true,
                     "service_data": {
                         "topic": "[[topic]]/ZoneCleaningCapability/start/set",
-                        "payload": "{\"zones\": [{%for s in ('[[selection]]')|from_json %}{ \"points\": {\"pA\": { \"x\": {{s[0]}}, \"y\": {{s[1]}} }, \"pB\": { \"x\": {{s[2]}}, \"y\": {{s[1]}} }, \"pC\": { \"x\": {{s[2]}}, \"y\": {{s[3]}} }, \"pD\": { \"x\": {{s[0]}}, \"y\": {{s[3]}} } }, \"iterations\": [[repeats]]}{%if not loop.last%},{%endif%}{%endfor%}]}"
+                        "payload": "{\"zones\": [{%for s in ('[[selection]]')|from_json %}{ \"points\": {\"pA\": { \"x\": {{s[0]}}, \"y\": {{s[1]}} }, \"pB\": { \"x\": {{s[2]}}, \"y\": {{s[1]}} }, \"pC\": { \"x\": {{s[2]}}, \"y\": {{s[3]}} }, \"pD\": { \"x\": {{s[0]}}, \"y\": {{s[3]}} } } }{%if not loop.last%},{%endif%}{%endfor%}], \"iterations\": [[repeats]]}"
                     }
                 }
             },
@@ -48,7 +48,7 @@
                     "evaluate_data_as_template": true,
                     "service_data": {
                         "topic": "[[topic]]/ZoneCleaningCapability/start/set",
-                        "payload": "{\"zones\": [{%for s in ('[[selection]]')|from_json %}{ \"points\": {\"pA\": { \"x\": {{s[0]}}, \"y\": {{s[1]}} }, \"pB\": { \"x\": {{s[2]}}, \"y\": {{s[1]}} }, \"pC\": { \"x\": {{s[2]}}, \"y\": {{s[3]}} }, \"pD\": { \"x\": {{s[0]}}, \"y\": {{s[3]}} } }, \"iterations\": [[repeats]]}{%if not loop.last%},{%endif%}{%endfor%}]}"
+                        "payload": "{\"zones\": [{%for s in ('[[selection]]')|from_json %}{ \"points\": {\"pA\": { \"x\": {{s[0]}}, \"y\": {{s[1]}} }, \"pB\": { \"x\": {{s[2]}}, \"y\": {{s[1]}} }, \"pC\": { \"x\": {{s[2]}}, \"y\": {{s[3]}} }, \"pD\": { \"x\": {{s[0]}}, \"y\": {{s[3]}} } } }{%if not loop.last%},{%endif%}{%endfor%}], \"iterations\": [[repeats]]}"
                     }
                 }
             },


### PR DESCRIPTION
For zone cleaning, the valetudo template has the number of repeats inside each object in the "zones" array.
```
{
  "zones": [
    {
      "points": {
        "pA": {
          "x": 3246,
          "y": 2632
        },
        "pB": {
          "x": 3546,
          "y": 2632
        },
        "pC": {
          "x": 3546,
          "y": 2833
        },
        "pD": {
          "x": 3246,
          "y": 2833
        }
      },
      "iterations": 3
    }
  ]
}
```

But this is incorrect.  Valetudo expects the number of repeats to be outside of the "zones" array.
```
{
  "zones": [
    {
      "points": {
        "pA": {
          "x": 3246,
          "y": 2632
        },
        "pB": {
          "x": 3546,
          "y": 2632
        },
        "pC": {
          "x": 3546,
          "y": 2833
        },
        "pD": {
          "x": 3246,
          "y": 2833
        }
      }
    }
  ],
  "iterations": 3
}
```

I've updated the template to put the number of repeats in the correct place.

I tested this by overriding the payload in the config for the map card and now my vacuum correctly does the specified number of repeats.