### PR TITLE
Fix setting of roborock repeat

### DIFF
--- a/src/model/generators/platform_templates/roborock.json
+++ b/src/model/generators/platform_templates/roborock.json
@@ -15,7 +15,7 @@
                         "command": "app_segment_clean",
                         "params": [{
                             "segments": "[[selection]]",
-                            "repeats": "[[repeats]]"
+                            "repeat": "[[repeats]]"
                         }],
                         "entity_id": "[[entity_id]]"
                     }

--- a/src/model/generators/platform_templates/roborock.json
+++ b/src/model/generators/platform_templates/roborock.json
@@ -35,6 +35,7 @@
                     "service_data": {
                         "command": "app_zoned_clean",
                         "params": "[[selection]]",
+                        "repeat": "[[repeats]]",
                         "entity_id": "[[entity_id]]"
                     }
                 }
@@ -53,6 +54,7 @@
                     "service_data": {
                         "command": "app_zoned_clean",
                         "params": "[[selection]]",
+                        "repeat": "[[repeats]]",
                         "entity_id": "[[entity_id]]"
                     }
                 }


### PR DESCRIPTION
Sends `repeat` instead of `repeats`. Added the repeat where they were missing too.
Fixes https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card/issues/862