### PR TITLE
Create a battery_level tile from the separate battery_level entity for Hypfer Valetudo vacuums

### DIFF
--- a/src/model/generators/platform_templates/hypfer_valetudo.json
+++ b/src/model/generators/platform_templates/hypfer_valetudo.json
@@ -89,8 +89,6 @@
                 "tile_id": "battery_level",
                 "unique_id_regex": "_sensor_battery_level",
                 "label": "tile.battery_level.label",
-                "attribute": "battery_level",
-                "icon_source": "[[entity_id]].attributes.icon",
                 "unit": "%"
             },
             {

--- a/src/model/generators/platform_templates/hypfer_valetudo.json
+++ b/src/model/generators/platform_templates/hypfer_valetudo.json
@@ -86,6 +86,14 @@
     "tiles": {
         "from_sensors": [
             {
+                "tile_id": "battery_level",
+                "unique_id_regex": "_sensor_battery_level",
+                "label": "tile.battery_level.label",
+                "attribute": "battery_level",
+                "icon_source": "[[entity_id]].attributes.icon",
+                "unit": "%"
+            },
+            {
                 "tile_id": "filter_left",
                 "unique_id_regex": "_sensor_ConsumableMonitoringCapability_filter_main",
                 "label": "tile.filter_left.label",


### PR DESCRIPTION
The existing tiles created [here](https://github.com/PiotrMachowski/lovelace-xiaomi-vacuum-map-card/blob/29a4a15b06b4213bdad63085ff3177990e77d9d5/src/model/generators/tiles-generator.ts#L115) no longer work for Valetudo vacuums since they publish the battery_level as a separate entity following this Home Assistant [architecture discussion](https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated/). 