### PR TITLE
Update localization support for Dreame vacuum tiles

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -221,6 +221,27 @@
         },
         "mop_pad_humidity": {
             "label": "Mop pad"
+        },
+        "cleaning_mode": {
+          "label": "Cleaning mode"
+        },
+        "tight_mopping": {
+          "label": "Tight mopping"
+        },
+        "wetness_level": {
+          "label": "Mop wetness"
+        },
+        "mop_wash_level": {
+          "label": "Mop washing"
+        },
+        "auto_empty_mode": {
+          "label": "Auto empty mode"
+        },
+        "cleaning_route": {
+          "label": "Cleaning route"
+        },
+        "cleangenius": {
+          "label": "CleanGenius"
         }
     },
     "icon": {

--- a/src/localize/languages/fr.json
+++ b/src/localize/languages/fr.json
@@ -185,11 +185,55 @@
         "cleaned_area": {
             "label": "Surface nettoyée"
         },
+        "total_cleaned_area": {
+          "label": "Surface total nettoyée"
+        },
         "cleaning_time": {
             "label": "Durée de nettoyage"
         },
         "mop_left": {
             "label": "Serpillère"
+        },
+        "bin_full": {
+          "label": "Bac plein",
+          "value": {
+            "true": "Oui",
+            "false": "Non"
+          }
+        },
+        "bin_present": {
+          "label": "Bac présent",
+          "value": {
+            "true": "Oui",
+            "false": "Non"
+          }
+        },
+        "water_volume": {
+          "label": "Volume d'eau"
+        },
+        "mop_pad_humidity": {
+          "label": "Humidité de la serpillière"
+        },
+        "cleaning_mode": {
+          "label": "Mode de nettoyage"
+        },
+        "tight_mopping": {
+          "label": "Nettoyage serré"
+        },
+        "wetness_level": {
+          "label": "Humidité de la serpillière"
+        },
+        "mop_wash_level": {
+          "label": "Lavage des serpillières"
+        },
+        "auto_empty_mode": {
+          "label": "Vidage automatique"
+        },
+        "cleaning_route": {
+          "label": "Trajectoire"
+        },
+        "cleangenius": {
+          "label": "CleanGenius"
         }
     },
     "icon": {


### PR DESCRIPTION
## Summary
This PR adds proper localization support for Dreame vacuum tiles
(cleaning mode, mop settings, auto-empty, trajectory, CleanGenius, etc.).

## Problem
When using Dreame vacuums, several tiles display raw localization keys
(e.g. `tile.cleaning_mode.label`) instead of translated labels.

## Solution
- Added missing localization keys using the existing nested format (`tile.xxx.label`)
- Ensured Dreame tiles always go through the localization system with safe fallback
- No breaking changes for other vacuum platforms

## Tested with
- Dreame L10s Ultra Gen2
- Home Assistant language: French
- lovelace-xiaomi-vacuum-map-card v2.3.x

## Screenshots
<img width="993" height="297" alt="image" src="https://github.com/user-attachments/assets/840ad7c5-8f07-4858-955b-53166eb06819" />
