### PR TITLE
fix: roborock.vacuum_goto - command does not exist error

### DIFF
--- a/src/model/generators/platform_templates/roborock.json
+++ b/src/model/generators/platform_templates/roborock.json
@@ -13,10 +13,12 @@
                     "service": "vacuum.send_command",
                     "service_data": {
                         "command": "app_segment_clean",
-                        "params": [{
-                            "segments": "[[selection]]",
-                            "repeat": "[[repeats]]"
-                        }],
+                        "params": [
+                            {
+                                "segments": "[[selection]]",
+                                "repeat": "[[repeats]]"
+                            }
+                        ],
                         "entity_id": "[[entity_id]]"
                     }
                 }
@@ -99,7 +101,7 @@
                 "service_call_schema": {
                     "service": "script.vacuum_follow_path",
                     "service_data": {
-                        "service": "roborock.vacuum_goto",
+                        "service": "roborock.set_vacuum_goto_position",
                         "mode": "individual",
                         "path": "[[selection]]",
                         "entity_id": "[[entity_id]]"
@@ -214,3 +216,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
Changes the service call in `vacuum_follow_path` from `roborock.vacuum_goto` to `roborock.set_vacuum_goto_position`, since the former command does not exist (it was renamed in this [PR](https://github.com/home-assistant/core/pull/133994#issuecomment-2563082997)) and is [documented here](https://www.home-assistant.io/integrations/roborock/#action-set-vacuum-goto-position).

It's unclear to me whether I need to change any of the service data parameters to ensure that the data is correctly passed to the service as expected. Some guidance here would be appreciated.

Changes need verifying as I do not have an appropriate environment setup to test the changes.

Related issue: #828.