### PR TITLE
Fix validation crashes for missing predefined selection fields

### DIFF
--- a/src/config-validators.ts
+++ b/src/config-validators.ts
@@ -121,8 +121,7 @@ function validatePredefinedRectangleConfig(ps: PredefinedSelectionConfig): Trans
     const errors: TranslatableString[] = [];
     if (!config.zones) {
         errors.push("validation.preset.map_modes.predefined_selections.zones.missing");
-    }
-    if (typeof config.zones !== "string" && config.zones.filter(z => z.length != 4).length > 0) {
+    } else if (typeof config.zones !== "string" && config.zones.filter(z => z.length != 4).length > 0) {
         errors.push("validation.preset.map_modes.predefined_selections.zones.invalid_parameters_number");
     }
     if (config.icon) {
@@ -157,8 +156,7 @@ function validateRoomConfig(ps: PredefinedSelectionConfig): TranslatableString[]
     const errors: TranslatableString[] = [];
     if (config.id === undefined) {
         errors.push("validation.preset.map_modes.predefined_selections.rooms.id.missing");
-    }
-    if (!config.id.toString().match(/^[A-Za-z0-9 _]+$/i)) {
+    } else if (!config.id.toString().match(/^[A-Za-z0-9 _]+$/i)) {
         errors.push([
             "validation.preset.map_modes.predefined_selections.rooms.id.invalid_format",
             "{0}",


### PR DESCRIPTION
Fixes validation crashes when predefined rectangle zones or room ids are missing.

The validator already reports these as configuration errors, but then continued to access the missing fields and crashed the card instead of showing the validation message.