### PR TITLE
Ignore invalid dynamic predefined selections

### DIFF
--- a/src/model/map_objects/predefined-multi-rectangle.ts
+++ b/src/model/map_objects/predefined-multi-rectangle.ts
@@ -5,7 +5,7 @@ import { forwardHaptic } from "custom-card-helpers";
 
 import { Context } from "./context";
 import { PredefinedZoneConfig, ZoneType, ZoneWithRepeatsType } from "../../types/types";
-import { deleteFromArray } from "../../utils";
+import { deleteFromArray, getDynamicPredefinedSelectionItems } from "../../utils";
 import { MapMode } from "../map_mode/map-mode";
 import { HomeAssistantFixed } from "../../types/fixes";
 import { PredefinedMapObject } from "./predefined-map-object";
@@ -27,17 +27,7 @@ export class PredefinedMultiRectangle extends PredefinedMapObject {
             .map(ps => ps as PredefinedZoneConfig)
             .filter(pzc => typeof pzc.zones === "string")
             .map(pzc => (pzc.zones as string).split(".attributes."))
-            .flatMap(z => {
-                const entity = hass.states[z[0]];
-                const value = z.length === 2 ? entity.attributes[z[1]] : entity.state;
-                let parsed;
-                try {
-                    parsed = JSON.parse(value) as ZoneType[];
-                } catch {
-                    parsed = value as ZoneType[];
-                }
-                return parsed;
-            })
+            .flatMap(z => getDynamicPredefinedSelectionItems(hass, z) as ZoneType[])
             .map(
                 z =>
                     new PredefinedMultiRectangle(

--- a/src/model/map_objects/predefined-point.ts
+++ b/src/model/map_objects/predefined-point.ts
@@ -9,7 +9,7 @@ import {
     PointWithRepeatsType,
     PredefinedPointConfig,
 } from "../../types/types";
-import { deleteFromArray } from "../../utils";
+import { deleteFromArray, getDynamicPredefinedSelectionItems } from "../../utils";
 import { MapMode } from "../map_mode/map-mode";
 import { HomeAssistantFixed } from "../../types/fixes";
 import { PredefinedMapObject } from "./predefined-map-object";
@@ -39,17 +39,7 @@ export class PredefinedPoint extends PredefinedMapObject {
             .map(ps => ps as PredefinedPointConfig)
             .filter(pzc => typeof pzc.position === "string")
             .map(pzc => (pzc.position as string).split(".attributes."))
-            .flatMap(z => {
-                const entity = hass.states[z[0]];
-                const value = z.length === 2 ? entity.attributes[z[1]] : entity.state;
-                let parsed;
-                try {
-                    parsed = JSON.parse(value) as PointType[];
-                } catch {
-                    parsed = value as PointType[];
-                }
-                return parsed;
-            })
+            .flatMap(p => getDynamicPredefinedSelectionItems(hass, p) as PointType[])
             .map(
                 p =>
                     new PredefinedPoint(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -346,3 +346,23 @@ export function getFilledTemplate(
     replaceInTarget(target, keyReplacer);
     return target;
 }
+
+export function getDynamicPredefinedSelectionItems(hass: HomeAssistant, source: string[]): unknown[] {
+    const entity = hass.states[source[0]];
+    if (!entity) {
+        return [];
+    }
+
+    const value = source.length === 2 ? entity.attributes[source[1]] : entity.state;
+
+    if (value === undefined || value === null) {
+        return [];
+    }
+
+    try {
+        const parsed = typeof value === "string" ? JSON.parse(value) : value;
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}


### PR DESCRIPTION
Prevents crashes when dynamic predefined zones or points reference a missing entity or invalid entity state.

Invalid dynamic selections are now ignored instead of breaking card rendering.