### PR TITLE
Preserve watched entities when loading presets

### DIFF
--- a/src/xiaomi-vacuum-map-card.ts
+++ b/src/xiaomi-vacuum-map-card.ts
@@ -57,7 +57,7 @@ import {
     createActionWithConfigHandler,
     delay,
     getMousePosition,
-    getWatchedEntities,
+    getWatchedEntities, getWatchedEntitiesForPreset,
     hasConfigOrAnyEntityChanged,
     stopEvent,
 } from "./utils";
@@ -601,7 +601,12 @@ export class XiaomiVacuumMapCard extends LitElement {
 
     private _setPreset(config: CardPresetConfig): void {
         this.currentPreset = config;
-        this.watchedEntities = getWatchedEntities({type: "", ...config});
+        this.watchedEntities = [
+            ...new Set([
+                ...getWatchedEntities(this.config),
+                ...getWatchedEntitiesForPreset(config, this.config.language),
+            ]),
+        ];
     }
 
     private _updateCalibration(config: CardPresetConfig): void {


### PR DESCRIPTION
Preserves watched entities from the full card configuration when a preset is loaded.

The active preset is now processed with getWatchedEntitiesForPreset() instead of passing a "preset" object to getWatchedEntities(), which expects the full card config.