### PR TITLE
Fix validation crash for incomplete calibration points

### DIFF
--- a/src/config-validators.ts
+++ b/src/config-validators.ts
@@ -42,7 +42,9 @@ function validateCalibrationPoint(calibrationPoint: CalibrationPoint): Translata
         errors.push("validation.preset.calibration_source.calibration_points.missing_vacuum");
     }
     if (
-        [calibrationPoint?.map, calibrationPoint?.vacuum].filter(p => p.x === undefined || p.y === undefined).length > 0
+        [calibrationPoint?.map, calibrationPoint?.vacuum]
+            .filter(p => p !== undefined)
+            .some(p => p.x === undefined || p.y === undefined)
     ) {
         errors.push("validation.preset.calibration_source.calibration_points.missing_coordinate");
     }


### PR DESCRIPTION
Fixes a validation crash when a calibration point is missing the map or vacuum section.

The validator already reports these as configuration errors, but then continued to check coordinates on the missing object.