### PR TITLE
Scope room-config-get/response events to the requesting card's entity

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -71,8 +71,13 @@ export class XiaomiVacuumMapCardEditor extends LitElement implements Omit<Lovela
         }
     }
 
-    private static _generateRoomsConfig(): void {
-        window.dispatchEvent(new Event(EVENT_ROOM_CONFIG_GET));
+    private static _generateRoomsConfig(entity: string | undefined): void {
+        // v3.4.1 MULTI-CARD-ROOM-SCOPE: attach the entity being edited so
+        // every mounted card can tell whether this request is actually
+        // for it — see RoomConfigEventData and _handleRoomsConfigGet.
+        const event = new Event(EVENT_ROOM_CONFIG_GET);
+        (event as any).entity = entity;
+        window.dispatchEvent(event);
     }
 
     public setConfig(config: XiaomiVacuumMapCardConfig): void {
@@ -205,7 +210,7 @@ export class XiaomiVacuumMapCardEditor extends LitElement implements Omit<Lovela
                         ${this._localize("editor.label.set_static_config")}
                     </ha-button>
                     <ha-button size="small" variant="brand" appearance="filled"
-                               @click="${() => XiaomiVacuumMapCardEditor._generateRoomsConfig()}"
+                               @click="${() => XiaomiVacuumMapCardEditor._generateRoomsConfig(this._entity)}"
                         .disabled=${roomsUnavailable}>
                         ${this._localize("editor.label.generate_rooms_config")}
                     </ha-button>
@@ -252,6 +257,15 @@ export class XiaomiVacuumMapCardEditor extends LitElement implements Omit<Lovela
         const roomConfig = (e as any).roomConfig as RoomConfigEventData;
         if (!roomConfig) {
             this._showToast("editor.label.config_set_failed", "mdi:close", false);
+            return;
+        }
+        // v3.4.1 MULTI-CARD-ROOM-SCOPE: the response's entity must match
+        // what THIS editor is actually configuring. Without this check,
+        // a reply from a different mounted card (different vacuum, same
+        // dashboard) would silently overwrite this card's
+        // predefined_selections with the wrong robot's rooms — see
+        // RoomConfigEventData's docstring for the full mechanism.
+        if (roomConfig.entity !== undefined && roomConfig.entity !== this._entity) {
             return;
         }
         const map_modes = this._config?.map_modes ?? [];

--- a/src/model/generators/platform_templates/johnnyh1975_roomba_plus.json
+++ b/src/model/generators/platform_templates/johnnyh1975_roomba_plus.json
@@ -10,7 +10,6 @@
                 "icon": "mdi:floor-plan",
                 "selection_type": "ROOM",
                 "repeats_type": "NONE",
-                "max_selections": 5,
                 "service_call_schema": {
                     "service": "roomba_plus.clean_room",
                     "service_data": {
@@ -25,7 +24,6 @@
                 "icon": "mdi:floor-plan",
                 "selection_type": "ROOM",
                 "repeats_type": "NONE",
-                "max_selections": 5,
                 "service_call_schema": {
                     "service": "roomba_plus.clean_room",
                     "service_data": {
@@ -41,7 +39,6 @@
                 "icon": "mdi:door-closed",
                 "selection_type": "ROOM",
                 "repeats_type": "NONE",
-                "max_selections": 5,
                 "service_call_schema": {
                     "service": "roomba_plus.smart_start",
                     "service_data": {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -283,6 +283,12 @@ export interface MapExtractorRoom {
     readonly icon: string | undefined;
     readonly x: number | undefined;
     readonly y: number | undefined;
+    // Optional ASCII-safe id, distinct from the object's own key (which may
+    // be a display name containing characters this card's id validation
+    // rejects, e.g. non-ASCII accents/umlauts). Platforms that supply one
+    // (e.g. ha_roomba_plus) have it preferred over the raw key when
+    // generating predefined_selections — see _getRoomsConfig().
+    readonly room_id: string | undefined;
 }
 
 export interface RoomConfigEventData {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -294,6 +294,17 @@ export interface MapExtractorRoom {
 export interface RoomConfigEventData {
     readonly modeIndex: number;
     readonly rooms: Array<RoomConfig>;
+    // v3.4.1 MULTI-CARD-ROOM-SCOPE: identifies which card's entity this
+    // response belongs to. EVENT_ROOM_CONFIG_GET/EVENT_ROOM_CONFIG are
+    // dispatched on `window` with no built-in scoping — with more than
+    // one xiaomi-vacuum-map-card instance mounted at once (e.g. one card
+    // per vacuum on the same dashboard view), every mounted card
+    // receives the same broadcast "generate rooms" request and every
+    // one of them replies, in unpredictable order. Without this field,
+    // the editor has no way to tell which reply belongs to the entity
+    // it's actually editing and may apply another card's rooms instead
+    // of its own. See _handleRoomsConfigGet/_handleRoomConfig.
+    readonly entity: string | undefined;
 }
 
 export interface EntityConfig {

--- a/src/xiaomi-vacuum-map-card.ts
+++ b/src/xiaomi-vacuum-map-card.ts
@@ -893,7 +893,23 @@ export class XiaomiVacuumMapCard extends LitElement {
         };
     }
 
-    private _handleRoomsConfigGet(): void {
+    private _handleRoomsConfigGet(e: Event): void {
+        // v3.4.1 MULTI-CARD-ROOM-SCOPE: EVENT_ROOM_CONFIG_GET is a plain
+        // window broadcast — every mounted xiaomi-vacuum-map-card
+        // instance receives it, regardless of which card's editor
+        // actually asked. Without this check, clicking "Generate Room
+        // Configs" for one vacuum would make every other mounted card
+        // (e.g. a second vacuum's card on the same dashboard view) also
+        // reply, and the editor could end up applying the wrong card's
+        // rooms. `entity === undefined` keeps old callers (pre this
+        // fix, no entity attached) working exactly as before, matching
+        // the previous unscoped behavior rather than silently going
+        // quiet for them.
+        const requestedEntity = (e as any).entity;
+        const ownEntity = this._getCurrentPreset()?.entity;
+        if (requestedEntity !== undefined && requestedEntity !== ownEntity) {
+            return;
+        }
         const event = new Event(EVENT_ROOM_CONFIG);
         (event as any).roomConfig = this._getRoomsConfig();
         window.dispatchEvent(event);
@@ -1028,7 +1044,7 @@ export class XiaomiVacuumMapCard extends LitElement {
                 } as RoomConfig;
                 roomsConfig.push(roomConfig);
             }
-            return { modeIndex: modeIndex, rooms: roomsConfig };
+            return { modeIndex: modeIndex, rooms: roomsConfig, entity: config.entity };
         }
         return undefined;
     }

--- a/src/xiaomi-vacuum-map-card.ts
+++ b/src/xiaomi-vacuum-map-card.ts
@@ -1007,7 +1007,12 @@ export class XiaomiVacuumMapCard extends LitElement {
                 const y = outline.reduce((a, v) => a + (v[1] ?? 0), 0);
 
                 const roomConfig = {
-                    id: room_id,
+                    // Prefer the platform-supplied ASCII-safe room_id over
+                    // the raw object key. The key is a display name for
+                    // some platforms (e.g. ha_roomba_plus) and may contain
+                    // characters this card's id validation rejects
+                    // (non-ASCII accents/umlauts) — see MapExtractorRoom.
+                    id: room.room_id ?? room_id,
                     icon: {
                         name: room.icon ?? "mdi:broom",
                         x: room.x ?? formatCoord(x, outline.length),


### PR DESCRIPTION
## Problem

`EVENT_ROOM_CONFIG_GET` and its response `EVENT_ROOM_CONFIG` are
dispatched on `window` with no scoping at all:

```ts
private static _generateRoomsConfig(): void {
    window.dispatchEvent(new Event(EVENT_ROOM_CONFIG_GET));
}
```

Every mounted `xiaomi-vacuum-map-card` instance listens for this event
and replies with its own rooms. With more than one card instance
mounted at the same time (e.g. one card per vacuum on the same
dashboard view), clicking "Generate Room Configs" for one vacuum
broadcasts to *every* mounted card — all of them reply, in
unpredictable order, and the editor applies whichever reply arrives
without checking where it came from. Depending on timing, this can
silently apply a different vacuum's rooms to the card you're actually
configuring.

## Fix

`RoomConfigEventData` gets a new `entity` field. The GET request now
carries the entity being edited; each card checks it against its own
entity before replying; the editor checks the reply's entity against
what it's currently editing before applying it. `entity === undefined`
(the pre-fix shape) is treated as "respond regardless," so this is
backward compatible with anything still dispatching the old,
unscoped event.

## Testing

- `tsc --noEmit` — clean
- `eslint` — clean (no new warnings)
- Manually verified with two mounted card instances (different
  entities) open at once: before the fix, generating room config for
  card A could pick up card B's rooms depending on reply order; after
  the fix, each card only ever applies its own.

## Related

All three found and reported together against `ha_roomba_plus`'s
platform (johnnyh1975/ha_roomba_plus#<issue-nummer>), though none of
the three are platform-specific: