### PR TITLE
Handle y coordinates parsed with YAML 1.1

### DIFF
--- a/src/config-normalizer.ts
+++ b/src/config-normalizer.ts
@@ -1,0 +1,68 @@
+import {
+    CalibrationPoint,
+    CardPresetConfig,
+    IconConfig,
+    LabelConfig,
+    Point,
+    PredefinedSelectionConfig,
+    XiaomiVacuumMapCardConfig,
+} from "./types/types";
+
+type Coordinate = Point | IconConfig | LabelConfig;
+
+function normalizeCoordinate<T extends Coordinate>(coordinate: T): T {
+    const rawCoordinate = coordinate as unknown as Record<string, unknown>;
+
+    if (coordinate.y !== undefined || rawCoordinate.true === undefined) {
+        return coordinate;
+    }
+
+    const { true: yaml11Y, ...rest } = rawCoordinate;
+    return { ...rest, y: yaml11Y } as unknown as T;
+}
+
+function normalizeCalibrationPoint(point: CalibrationPoint): CalibrationPoint {
+    return {
+        ...point,
+        map: normalizeCoordinate(point.map),
+        vacuum: normalizeCoordinate(point.vacuum),
+    };
+}
+
+function normalizePredefinedSelection(selection: PredefinedSelectionConfig): PredefinedSelectionConfig {
+    return {
+        ...selection,
+        ...(selection.icon && { icon: normalizeCoordinate(selection.icon) }),
+        ...(selection.label && { label: normalizeCoordinate(selection.label) }),
+    };
+}
+
+function normalizePreset<T extends CardPresetConfig>(preset: T): T {
+    return {
+        ...preset,
+        ...(preset.calibration_source?.calibration_points && {
+            calibration_source: {
+                ...preset.calibration_source,
+                calibration_points: preset.calibration_source.calibration_points.map(normalizeCalibrationPoint),
+            },
+        }),
+        ...(preset.map_modes && {
+            map_modes: preset.map_modes.map(mode => ({
+                ...mode,
+                ...(mode.predefined_selections && {
+                    predefined_selections: mode.predefined_selections.map(normalizePredefinedSelection),
+                }),
+            })),
+        }),
+    };
+}
+
+/** Restore y coordinate keys parsed as boolean true by Home Assistant's YAML 1.1 editor. */
+export function normalizeConfig(config: XiaomiVacuumMapCardConfig): XiaomiVacuumMapCardConfig {
+    return {
+        ...normalizePreset(config),
+        ...(config.additional_presets && {
+            additional_presets: config.additional_presets.map(normalizePreset),
+        }),
+    };
+}

--- a/src/xiaomi-vacuum-map-card.ts
+++ b/src/xiaomi-vacuum-map-card.ts
@@ -65,6 +65,7 @@ import { PredefinedPoint } from "./model/map_objects/predefined-point";
 import { PredefinedMultiRectangle } from "./model/map_objects/predefined-multi-rectangle";
 import { Room } from "./model/map_objects/room";
 import { areAllEntitiesDefined, isOldConfig, validateConfig } from "./config-validators";
+import { normalizeConfig } from "./config-normalizer";
 import { MapMode } from "./model/map_mode/map-mode";
 import { SelectionType } from "./model/map_mode/selection-type";
 import { RepeatsType } from "./model/map_mode/repeats-type";
@@ -211,7 +212,7 @@ export class XiaomiVacuumMapCard extends LitElement {
         if (!config) {
             throw new Error(this._localize("common.invalid_configuration"));
         }
-        this.config = config;
+        this.config = normalizeConfig(config);
         if (isOldConfig(config)) {
             this.oldConfig = true;
             return;


### PR DESCRIPTION
## What changed

- normalize coordinate objects before validation and rendering
- restore `y` from the boolean `true` key produced by YAML 1.1 parsing
- cover predefined labels and icons, explicit calibration points, and additional presets
- preserve valid configurations and avoid mutating the input object

## Why

Home Assistant frontend 2026.8 upgraded to `js-yaml` v5 and now uses `YAML11_SCHEMA`. YAML 1.1 interprets an unquoted `y` mapping key as boolean `true`, so valid configuration such as:

```yaml
label:
  text: Room
  x: 16000
  y: 31175
```

reaches the card as `{ text: "Room", x: 16000, true: 31175 }`. The validator therefore reports `Label must have y property`, and the card does not render. Normalizing this parser representation at the config boundary restores backward compatibility for existing dashboards.

Addresses Python-roborock/RoborockCustomMap#44.

## Validation

- `npm run lint` (passes with the repository's existing unused-decorator warnings)
- `npx tsc --noEmit`
- Rollup production bundle under Node.js 16 (the repository's legacy Rollup/tslib stack does not run under Node.js 24)
- runtime assertions for labels, icons, calibration points, additional presets, and input immutability
