### PR TITLE
Fix frozen map_modes mutation in room config generator

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -254,7 +254,7 @@ export class XiaomiVacuumMapCardEditor extends LitElement implements Omit<Lovela
             this._showToast("editor.label.config_set_failed", "mdi:close", false);
             return;
         }
-        const map_modes = this._config?.map_modes ?? [];
+        const map_modes = [...(this._config?.map_modes ?? [])];
         if (map_modes.length !== 0 && (roomConfig.modeIndex ?? -1) >= 0) {
             map_modes[roomConfig.modeIndex ?? -1] = {
                 ...map_modes[roomConfig.modeIndex ?? -1],


### PR DESCRIPTION
## Summary

Fixes #932.

`_handleRoomConfig` assigned into `this._config.map_modes` (or pushed onto it) when generating room config. Home Assistant freezes Lovelace arrays, so that throws `TypeError: Cannot assign to read only property '3' of object '[object Array]'`.

This showed up with an existing `map_modes` list: the reporter's Dreame case (`dreame.vacuum.r2338a`, Tasshack/dreame-vacuum) has `vacuum_clean_segment` at index 3, which is the frozen slot the generator tried to replace.

Copy the array first so the editor can update or append modes, then write the new config back as usual.

## Test plan

- [ ] Card editor: Generate rooms with no `map_modes` (defaults still appended)
- [ ] Card editor: Generate rooms with existing `map_modes` including `vacuum_clean_segment` (e.g. at index 3) — should update that mode instead of throwing
- [ ] Confirm the generated config is written to the card and no console TypeError appears

Made with [Cursor](https://cursor.com)